### PR TITLE
Update step2-probes-without-endpoint.yaml with fixed docker image

### DIFF
--- a/kubernetes/ready-live-probes/readiness-full-demo/step2-probes-without-endpoint.yaml
+++ b/kubernetes/ready-live-probes/readiness-full-demo/step2-probes-without-endpoint.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: app-ready-example
-        image: ghcr.io/guymenahem/app-no-probes:0.0.1
+        image: ghcr.io/guymenahem/app-no-probes:0.0.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This commit https://github.com/guymenahem/how-to-devops-tools/commit/54a97247d80a3e816391f8ad25db995afbf9ab71 fixed a directory name mismatch. The `app-no-probes` docker image version `0.0.2` has the fix, so the `step2-probes-without-endpoint.yaml` file should be updated as well.