### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository overview
+
+This is a collection of ~30 independent DevOps/Kubernetes tutorial modules (not a unified application). Each top-level directory is a standalone demo with its own README, manifests, and optional sample apps. There is no root-level build, test, or lint command that covers the entire repo.
+
+### Runnable components
+
+| Component | Language | Path | Key commands |
+|---|---|---|---|
+| Echo Operator | Go 1.21 | `operator-framework/echo-operator/` | `go build -o bin/manager cmd/main.go`, `go vet ./...`, `go fmt ./...` |
+| Prometheus sample app | Python (Flask) | `prometheus-grafana/sample-app/` | `python3 app.py` (serves on port 8080) |
+| gRPC Node.js client | Node.js | `grpc/demo/node-estimation-client/` | `npm install && node client.js` |
+| Various Python demo apps | Python (Flask) | `kubernetes/ready-live-probes/`, `dapr/`, `buildpacks/` | `pip install -r requirements.txt && python3 app.py` |
+
+### Go operator caveats
+
+- The Makefile's `manifests` and `generate` targets use `controller-gen v0.12.0`, which crashes with Go >= 1.22 due to a nil-pointer dereference in `go/types`. Since the generated files (`api/v1/zz_generated.deepcopy.go`, `config/crd/bases/`) are already committed, you can build and test without running those targets.
+- To build: `go build -o bin/manager cmd/main.go`
+- To test: install `setup-envtest` into `bin/`, then run:
+  ```
+  KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.27.1 --bin-dir $(pwd)/bin -p path)" go test ./... -coverprofile cover.out
+  ```
+
+### Python demo apps
+
+Each Python demo app has its own `requirements.txt`. Install with `pip3 install -r requirements.txt` from the app directory. Most apps are Flask-based and serve on port 8080.
+
+### No unified CI or linting
+
+There is no repo-wide linter, test runner, or CI configuration. Lint/test/build commands are per-module as documented in each module's README.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this repository.

### What's included

- Repository overview documenting the tutorial-collection architecture
- Table of runnable components (Go operator, Python Flask apps, Node.js gRPC client) with key commands
- Known caveat about `controller-gen v0.12.0` incompatibility with Go >= 1.22 and workaround
- Per-module dependency and run instructions

### Verified during setup

| Check | Status |
|---|---|
| Go operator build (`go build -o bin/manager cmd/main.go`) | Pass |
| Go lint (`go fmt ./...`, `go vet ./...`) | Pass |
| Go tests (envtest) | Pass |
| Python Flask app (prometheus-grafana/sample-app) | Running on port 8080, `/` and `/metrics` endpoints verified |
| Node.js gRPC client deps (`npm install`) | Installed |

### Evidence

Go operator build, lint, and test output:
[go_operator_output.log](https://cursor.com/agents/bc-a993b4e5-0738-4c5b-af1a-4c1f2cb194d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_operator_output.log)

Flask demo app endpoint output:
[flask_demo_output.log](https://cursor.com/agents/bc-a993b4e5-0738-4c5b-af1a-4c1f2cb194d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fflask_demo_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a993b4e5-0738-4c5b-af1a-4c1f2cb194d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a993b4e5-0738-4c5b-af1a-4c1f2cb194d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

