### PR TITLE
Set up Cursor Cloud dev environment (Docker + K8s tooling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+`how-to-devops-tools` is an educational monorepo. Each top-level directory (e.g. `argocd`, `istio`,
+`prometheus-grafana`, `kubernetes`, `grpc`, `dapr`, `crossplane`, ...) is a **standalone hands-on
+demo** for a specific DevOps / cloud-native tool. It is mostly Kubernetes YAML, Helm values, and
+small sample apps (Python/Go/Node). There is **no repo-wide build/lint/test/run command** — pick a
+demo directory and follow its own `README.md`.
+
+Pre-installed dev tooling (captured in the VM snapshot): `docker`, `kubectl`, `helm`, `k3d`, plus
+`go`, `python3`/`pip3`, and `node`/`npm`. Sample-app Python/Node deps are installed per-demo
+(`pip install -r requirements.txt`, `npm install`); Go deps are pre-warmed by the startup update
+script.
+
+### Docker must be started manually each session
+The Docker daemon is **not** running automatically on a fresh VM. Start it before building images or
+running containers:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+```
+
+The daemon is pre-configured in `/etc/docker/daemon.json` to use the `fuse-overlayfs` storage driver
+with `containerd-snapshotter` disabled (required for Docker-in-Docker in this VM — do not remove).
+
+### IMPORTANT: local Kubernetes clusters do NOT run in this VM
+Do not spend time trying to start a cluster with `k3d` / `kind` / `minikube` — the kubelet fails with
+`failed to find memory cgroup (v2)`. The VM's cgroup-v2 root is `domain threaded`, so the `memory`
+(and `io`/`hugetlb`) controllers cannot be delegated to child cgroups (`+memory` on
+`/sys/fs/cgroup/cgroup.subtree_control` returns `ENOTSUP`). Regular `docker run` works, but
+`docker run --memory=...` also fails for the same reason. This is a host/infra limitation, not a
+missing dependency.
+
+Consequences for testing demos here:
+- You **can** build sample-app images (`docker build`) and run them directly (`docker run -p ...`),
+  and run the Go/Python/Node sample apps natively.
+- You **cannot** verify `kubectl apply` / `helm install` against a live local cluster in this VM.
+  `kubectl` and `helm` are installed and usable as CLIs (e.g. `helm template`, `kubectl --help`,
+  chart linting), but there is no API server to deploy to. If a task truly needs a running cluster,
+  it must run on infra where cgroup-v2 memory delegation is available.
+
+### Running a sample app (example workflow)
+The `prometheus-grafana/sample-app` Flask app is a good smoke test:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &        # if not already running
+cd prometheus-grafana/sample-app
+sudo docker build -t sample-app:dev .
+sudo docker run -d --name sample-app -p 8080:8080 sample-app:dev
+curl http://localhost:8080/          # -> Hello, World!
+curl http://localhost:8080/metrics   # -> Prometheus metrics incl. requests_per_second
+```
+
+Native Go example (`buildpacks/go-app`):
+
+```bash
+cd buildpacks/go-app
+go build -o /tmp/go-app .
+PORT=8090 /tmp/go-app &
+curl http://localhost:8090/          # -> <h1>Hello World!</h1>
+```
+
+Use `sudo` with `docker` (the `ubuntu` user is in the `docker` group, but the group only applies to
+new login sessions).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this educational DevOps monorepo and documents durable, non-obvious startup caveats for future cloud agents.

- Installed system tooling (captured in VM snapshot): Docker (with `fuse-overlayfs` + `containerd-snapshotter: false` for Docker-in-Docker), `kubectl`, `helm`, `k3d`. Go/Python/Node were already present.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the repo layout, how to start Docker each session, how to build/run sample apps, and the key cgroup limitation below.
- Registered a minimal startup update script that pre-warms Go module caches for the Go sample projects (idempotent, guarded, non-fatal).

## Key environment limitation

Local Kubernetes clusters (`k3d`/`kind`/`minikube`) **cannot run in this VM**: the cgroup-v2 root is `domain threaded`, so the `memory` controller cannot be delegated (`+memory` on `cgroup.subtree_control` returns `ENOTSUP`) and the kubelet fails with `failed to find memory cgroup (v2)`. Regular `docker run` works; `docker run --memory` does not. This is a host/infra limitation, not a missing dependency. Demos are therefore exercised by building images and running containers/apps directly.

## Hello-world verification

Built and ran `prometheus-grafana/sample-app` (Flask) via Docker and confirmed both endpoints, and built+ran `buildpacks/go-app` natively.

[sample_app_flask_metrics_demo.mp4](https://cursor.com/agents/bc-2a27cb6e-6743-42cf-afd3-11120f5e7667/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsample_app_flask_metrics_demo.mp4)

[Hello World page](https://cursor.com/agents/bc-2a27cb6e-6743-42cf-afd3-11120f5e7667/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_page.webp)
[Prometheus metrics with requests_per_second](https://cursor.com/agents/bc-2a27cb6e-6743-42cf-afd3-11120f5e7667/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetrics_requests_per_second.webp)

## Testing
- `docker build -t sample-app:dev .` + `docker run -p 8080:8080` -> `GET /` returns `Hello, World!`, `GET /metrics` returns Prometheus metrics incl. `requests_per_second`
- `go build` + run of `buildpacks/go-app` -> `GET /` returns `<h1>Hello World!</h1>`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a27cb6e-6743-42cf-afd3-11120f5e7667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a27cb6e-6743-42cf-afd3-11120f5e7667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

